### PR TITLE
Use modern way to publish package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
 name: Publish to PyPI
 
+concurrency: release
+
 on:
   release:
     types: [published]
@@ -11,6 +13,9 @@ jobs:
       matrix:
         python-version: ["3.10"]
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Publish in environment without PyPI token.