### PR TITLE
Regenerate for GRPC 1.66.2

### DIFF
--- a/ghome_foyer_api/api_pb2.py
+++ b/ghome_foyer_api/api_pb2.py
@@ -6,12 +6,10 @@
 
 from __future__ import annotations
 
-from google.protobuf import (
-    descriptor as _descriptor,
-    descriptor_pool as _descriptor_pool,
-    runtime_version as _runtime_version,
-    symbol_database as _symbol_database,
-)
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import descriptor_pool as _descriptor_pool
+from google.protobuf import runtime_version as _runtime_version
+from google.protobuf import symbol_database as _symbol_database
 from google.protobuf.internal import builder as _builder
 
 _runtime_version.ValidateProtobufRuntimeVersion(

--- a/ghome_foyer_api/api_pb2_grpc.py
+++ b/ghome_foyer_api/api_pb2_grpc.py
@@ -7,7 +7,7 @@ import grpc
 
 from ghome_foyer_api import api_pb2 as ghome__foyer__api_dot_api__pb2
 
-GRPC_GENERATED_VERSION = "1.67.1"
+GRPC_GENERATED_VERSION = "1.66.2"
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 


### PR DESCRIPTION
Home Assistant uses older version of GRPC, need to make stubs compatible.