### PR TITLE
Relax requirement on protobuf version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
     "grpcio>=1.71.0,<2",
-    "protobuf>=5.29.5",
+    "protobuf>=5.29.2",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "grpcio", specifier = ">=1.71.0,<2" },
-    { name = "protobuf", specifier = ">=5.29.5" },
+    { name = "protobuf", specifier = ">=5.29.2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
It should allow dependencies to be resolved on HA 2025.5.0.

Fix for https://github.com/leikoilja/ha-google-home/issues/947